### PR TITLE
Fix URI Encoding bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "korean-spell-checker-vs-code",
   "displayName": "Korean Spell Checker VS Code",
   "description": "",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "engines": {
     "vscode": "^1.38.0"
   },

--- a/src/commands/spell-check.ts
+++ b/src/commands/spell-check.ts
@@ -3,10 +3,11 @@ import { window, ViewColumn } from 'vscode';
 import { SpellCheck } from '../services/spell-checker';
 
 const STYLE = `<style>
-.red_text { color: red; }
-.green_text { color: green; }
-.blue_text { color: blue; }
-.violet_text { color: purple; }
+.red_text { color: #f44336; }
+.green_text { color: #4caf50; }
+.blue_text { color: #2196f3; }
+.violet_text { color: #9c27b0; }
+body { padding: 16px; font-size: 15px; line-height: 22px;}
 </style>`;
 
 let panel: any;

--- a/src/commands/spell-fix.ts
+++ b/src/commands/spell-fix.ts
@@ -12,7 +12,7 @@ const getText = curry((textline: TextLine, selection: Selection) => {
   const { lineNumber } = textline;
   if (lineNumber === selection.start.line) {
     return new Range(
-      selection.start, textline.rangeIncludingLineBreak.end)
+      selection.start, textline.rangeIncludingLineBreak.end);
   }
 
   if (lineNumber === selection.end.line) {
@@ -20,7 +20,7 @@ const getText = curry((textline: TextLine, selection: Selection) => {
   }
 
   return textline.rangeIncludingLineBreak;
-})
+});
 
 export const spellFix = async () => {
   const editor = window.activeTextEditor;

--- a/src/services/spell-checker.ts
+++ b/src/services/spell-checker.ts
@@ -6,7 +6,7 @@ const MAX_TEXT_COUNT = 500;
 
 export const SpellCheck = async (text: string): Promise<any> => {
   const { data } = await axios.get(
-    encodeURI(URL + text.slice(0, MAX_TEXT_COUNT))
+    URL + encodeURIComponent(text.slice(0, MAX_TEXT_COUNT))
   );
   return data.message.result;
 };


### PR DESCRIPTION
Fix URI Encoding bug when query special charaters like `#`.
Instead of `encodeURI`, it used `enocdeURIComponent` and applied
it only to queries.

See also
  - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI
  - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent